### PR TITLE
handle ctrl and alt modifiers different for linux

### DIFF
--- a/lib/key-mapper.coffee
+++ b/lib/key-mapper.coffee
@@ -33,9 +33,12 @@ class KeyMapper
           charCode = translation.shifted
           keyDownEvent.shiftKey = false
         else if translation.alted? && @modifierStateHandler.isAltGr()
-          charCode = translation.alted
-          keyDownEvent.altKey = false
-          keyDownEvent.ctrlKey = false
+          # do not remove alt+ctrl states for linux
+          # TODO: what about darwin?
+          if process.platform != 'linux'
+            console.log('removing ctrl and alt modifiers')
+            keyDownEvent.altKey = false
+            keyDownEvent.ctrlKey = false
         else if translation.unshifted?
           charCode = translation.unshifted
 


### PR DESCRIPTION
Do not remove the ctrl and alt modifiers on linux if we are in altgr state, since that would prevent cltr/alt shortcuts from working with special keys that require altgr pressed.
